### PR TITLE
Add Scripts when AdGuard is installed

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -1,0 +1,4 @@
+if [ -d /data/app/*'=='/'com.adguard.android'*'==' ]; then
+mkdir -p $MODPATH/system/app/com.adguard.android
+cp -r /data/app/*'=='/'com.adguard.android'*'=='/* $MODPATH/system/app/com.adguard.android/
+fi


### PR DESCRIPTION
Making it a system application only when AdGuard is installed on the device to reduce module capacity